### PR TITLE
拡張機能アイコンとホワイトスペース色の追加

### DIFF
--- a/themes/Metroid-color-theme.json
+++ b/themes/Metroid-color-theme.json
@@ -11,7 +11,8 @@
 		"sideBarTitle.foreground": "#59c3ad",
 		"statusBar.background": "#59c3ad",
 		"statusBar.foreground": "#000000",
-		"editorInlayHint.foreground": "#c7c7c7"
+		"editorInlayHint.foreground": "#c7c7c7",
+		"editorWhitespace.foreground": "#398E92"
 	},
 	"tokenColors": [
 		{


### PR DESCRIPTION
## 概要
- 拡張機能のアイコン (images/icon.png) を追加し、package.jsonに設定
- テーマにeditorWhitespace.foregroundの色を追加
- バージョンを0.0.3に更新

## テスト計画
- [ ] VS Codeで拡張機能を再読み込みし、アイコンが表示されることを確認
- [ ] エディタで空白文字表示を有効にし、色が反映されることを確認